### PR TITLE
add archlinux-appstream-data

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -104,6 +104,7 @@ zsh
 
 #Arch Linux GUI KDE Plasma
 plasma
+archlinux-appstream-data
 xorg
 sddm
 bash-completion


### PR DESCRIPTION
Dicover was unable to  load packages because archlinux-appstream-data package was not installed which  is required by AppStream-based software centers like discover.